### PR TITLE
renovateの設定を変更

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,11 +2,15 @@
   "extends": ["config:base"],
   "timezone": "Asia/Tokyo",
   "labels": ["renovate"],
-  "schedule": "every weekend",
+  "schedule": "every weekday",
   "baseBranches": ["chore/renovate"],
   "packageRules": [
     {
       "updateTypes": ["minor", "patch", "pin", "digest"],
+      "automerge": true
+    },
+    {
+      "depTypeList": ["devDependencies"],
       "automerge": true
     }
   ]


### PR DESCRIPTION
close #351

- devDependencies は問答無用でautomerge
  - masterにいきなり行くわけではないので問題ないはず
- schedule を週末から平日に変更
  - 稼働する可能性のある週末にVercelのビルドが専有されるのは辛い