### PR TITLE
フォントをNunitoに変更しタイトルのみに適用

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,4 +1,4 @@
 <link
   rel="stylesheet"
-  href="https://fonts.googleapis.com/css?family=M+PLUS+Rounded+1c:400,700&display=swap"
+  href="https://fonts.googleapis.com/css2?family=Nunito:wght@700&amp;display=swap&amp;text=hbsnow.dev"
 />

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -60,6 +60,7 @@ const Header: FC = () => {
         }
 
         .siteTitle {
+          font-family: 'Nunito', sans-serif;
           font-size: 1.5rem;
           margin: 0;
         }

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -49,9 +49,7 @@ class BaseDocument extends Document {
 
           <link
             rel="stylesheet"
-            // https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@400;700&display=swap
-            // 上記の新APIだとAMP Validationでエラーになる
-            href="https://fonts.googleapis.com/css?family=M+PLUS+Rounded+1c:400,700&display=swap"
+            href="https://fonts.googleapis.com/css2?family=Nunito:wght@700&amp;display=swap&amp;text=hbsnow.dev"
           />
         </Head>
         <body>

--- a/src/styles/globalStyles.tsx
+++ b/src/styles/globalStyles.tsx
@@ -57,7 +57,7 @@ const globalStyles = css.global`
   body {
     color: var(--color-default-text);
     background-color: var(--color-default-bg);
-    font-family: 'M PLUS Rounded 1c', sans-serif;
+    font-family: sans-serif;
     line-height: 1.5;
     -webkit-text-size-adjust: 100%;
     -webkit-tap-highlight-color: rgba(0, 0, 0, 0);


### PR DESCRIPTION
- フォントをNunitoに変更しタイトルのみに適用
- AMP Validationで警告がでなくなったため、Google Font API を v2 に更新

before | after
---|---
![スクリーンショット 2020-06-27 21 36 56](https://user-images.githubusercontent.com/661266/85922460-60781180-b8be-11ea-80ea-a6c08491d5c5.png)|![スクリーンショット 2020-06-27 21 36 43](https://user-images.githubusercontent.com/661266/85922458-5eae4e00-b8be-11ea-9dfd-89e06e965c62.png)
