### PR TITLE
React.FCを廃止して、PropsWithChildrenを使うように変更

### DIFF
--- a/src/components/blog/BlogHeader.tsx
+++ b/src/components/blog/BlogHeader.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from "react";
+import React from "react";
 
 import classNames from "classnames";
 
@@ -10,7 +10,9 @@ type Props = {
   post: BlogType;
 };
 
-const BlogHeader: FC<Props> = ({ post }) => {
+const BlogHeader = (props: Props): JSX.Element => {
+  const { post } = props;
+
   const createdAt = useFormattedDate(post.createdAt);
   const updatedAt = useFormattedDate(post.updatedAt);
 

--- a/src/components/blog/BlogList.tsx
+++ b/src/components/blog/BlogList.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from "react";
+import React from "react";
 
 import { TagType } from "../../elements/icon/Icon";
 import { BlogType } from "../../modules/blog";
@@ -9,7 +9,9 @@ type Props = {
   preferredTag?: TagType;
 };
 
-const BlogList: FC<Props> = ({ blogList, preferredTag }) => {
+const BlogList = (props: Props): JSX.Element => {
+  const { blogList, preferredTag } = props;
+
   return (
     <ul className="blogList">
       {blogList?.map((post) => {

--- a/src/components/blog/BlogListItem.tsx
+++ b/src/components/blog/BlogListItem.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from "react";
+import React from "react";
 
 import classNames from "classnames";
 import Link from "next/link";
@@ -14,7 +14,9 @@ type Props = {
   preferredTag?: TagType;
 };
 
-const BlogListItem: FC<Props> = ({ post, preferredTag }) => {
+const BlogListItem = (props: Props): JSX.Element => {
+  const { post, preferredTag } = props;
+
   const createdAt = useFormattedDate(post.createdAt);
   const updatedAt = useFormattedDate(post.updatedAt);
 

--- a/src/components/book/Book.tsx
+++ b/src/components/book/Book.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from "react";
+import React from "react";
 
 import { Entry } from "contentful";
 
@@ -9,7 +9,9 @@ type Props = {
   book: Entry<IBookFields>["fields"];
 };
 
-const Book: FC<Props> = ({ book }) => {
+const Book = (props: Props): JSX.Element => {
+  const { book } = props;
+
   return (
     <div className="book">
       <header className="header">

--- a/src/components/book/BookList.tsx
+++ b/src/components/book/BookList.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from "react";
+import React from "react";
 
 import { Entry } from "contentful";
 
@@ -12,7 +12,9 @@ type Props = {
   bookList: Entry<IBookFields>[];
 };
 
-const BookList: FC<Props> = ({ bookList }) => {
+const BookList = (props: Props): JSX.Element => {
+  const { bookList } = props;
+
   const sortedBookList = useSort(bookList);
   const groupByCategoryBookList = useGroupByCategory(sortedBookList);
 

--- a/src/components/footer/Footer.tsx
+++ b/src/components/footer/Footer.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from "react";
+import React from "react";
 
 import Link from "next/link";
 
@@ -24,7 +24,7 @@ const sns: Readonly<SnsLink[]> = [
   },
 ];
 
-const Footer: FC = () => {
+const Footer = (): JSX.Element => {
   return (
     <footer className="footer">
       <Container>

--- a/src/components/head/JsonLd.tsx
+++ b/src/components/head/JsonLd.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from "react";
+import React from "react";
 
 import { ArticleJsonLd, BlogJsonLd } from "next-seo";
 
@@ -19,7 +19,9 @@ export type JsonLdType = {
 
 type Props = Readonly<JsonLdType>;
 
-const JsonLd: FC<Props> = ({ type, ...rest }) => {
+const JsonLd = (props: Props): JSX.Element => {
+  const { type, ...rest } = props;
+
   switch (type) {
     case "article": {
       return <ArticleJsonLd {...rest} />;

--- a/src/components/head/Meta.tsx
+++ b/src/components/head/Meta.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from "react";
+import React from "react";
 
 import { NextSeo } from "next-seo";
 
@@ -15,14 +15,9 @@ type Props = {
   updatedAt?: string;
 };
 
-const Meta: FC<Props> = ({
-  type,
-  title,
-  path,
-  description,
-  createdAt,
-  updatedAt,
-}) => {
+const Meta = (props: Props): JSX.Element => {
+  const { type, title, path, description, createdAt, updatedAt } = props;
+
   const pageUrl = useFullPath(path);
   const dateFormat = "YYYY-MM-DDTHH:mm:ss+09:00";
   const datePublished = useFormattedDate(createdAt, dateFormat);

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -1,11 +1,11 @@
-import React, { FC } from "react";
+import React from "react";
 
 import Link from "next/link";
 
 import Container from "../../elements/container/Container";
 import { mediaQuery } from "../../styles/const";
 
-const Header: FC = () => {
+const Header = (): JSX.Element => {
   return (
     <header className="header">
       <Container>

--- a/src/components/home/Avatar.tsx
+++ b/src/components/home/Avatar.tsx
@@ -1,10 +1,12 @@
-import React, { FC } from "react";
+import React from "react";
 
 type Props = {
   size?: number;
 };
 
-const Avatar: FC<Props> = ({ size = 256 }) => {
+const Avatar = (props: Props): JSX.Element => {
+  const { size = 256 } = props;
+
   return (
     <div className="avatar" data-amp-auto-lightbox-disable>
       <amp-img

--- a/src/components/home/HomeAbout.tsx
+++ b/src/components/home/HomeAbout.tsx
@@ -1,9 +1,13 @@
-import React, { FC } from "react";
+import React, { PropsWithChildren } from "react";
 
 import { mediaQuery } from "../../styles/const";
 import Avatar from "./Avatar";
 
-const HomeAbout: FC = ({ children }) => {
+type Props = PropsWithChildren<unknown>;
+
+const HomeAbout = (props: Props): JSX.Element => {
+  const { children } = props;
+
   return (
     <div className="homeAbout">
       <div className="avatarCell">

--- a/src/components/tag/TagList.tsx
+++ b/src/components/tag/TagList.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from "react";
+import React from "react";
 
 import Link from "next/link";
 
@@ -11,7 +11,9 @@ type Props = {
   preferredTag?: TagType;
 };
 
-const TagList: FC<Props> = ({ tagList, preferredTag }) => {
+const TagList = (props: Props): JSX.Element => {
+  const { tagList, preferredTag } = props;
+
   const sortedTagList = useSortedTagList(tagList, preferredTag);
 
   return (

--- a/src/elements/accent/Accent.tsx
+++ b/src/elements/accent/Accent.tsx
@@ -1,8 +1,12 @@
-import React, { ComponentPropsWithoutRef, FC } from "react";
+import React, { ComponentPropsWithoutRef, PropsWithChildren } from "react";
 
-export type Props = Omit<ComponentPropsWithoutRef<"div">, "className">;
+export type Props = PropsWithChildren<
+  Omit<ComponentPropsWithoutRef<"div">, "className">
+>;
 
-const Accent: FC<Props> = ({ children, ...rest }) => {
+const Accent = (props: Props): JSX.Element => {
+  const { children, ...rest } = props;
+
   return (
     <div data-testid="Accent" className="accent" {...rest}>
       {children}

--- a/src/elements/blockcode/Blockcode.tsx
+++ b/src/elements/blockcode/Blockcode.tsx
@@ -1,4 +1,4 @@
-import React, { ComponentPropsWithoutRef, FC } from "react";
+import React, { ComponentPropsWithoutRef, PropsWithChildren } from "react";
 
 import {
   Prism as SyntaxHighlighter,
@@ -9,11 +9,14 @@ import { mediaQuery } from "../../styles/const";
 import Code from "./Code";
 import Pre from "./Pre";
 
-export type Props = {
+export type Props = PropsWithChildren<{
   language?: SyntaxHighlighterProps["language"];
-} & Omit<ComponentPropsWithoutRef<"div">, "className">;
+}> &
+  Omit<ComponentPropsWithoutRef<"div">, "className">;
 
-const Blockcode: FC<Props> = ({ children, language, ...rest }) => {
+const Blockcode = (props: Props): JSX.Element => {
+  const { children, language, ...rest } = props;
+
   return (
     <div data-testid="Blockcode" className="blockcode" {...rest}>
       {language ? (

--- a/src/elements/blockcode/Code.tsx
+++ b/src/elements/blockcode/Code.tsx
@@ -1,6 +1,10 @@
-import React, { FC } from "react";
+import React, { PropsWithChildren } from "react";
 
-const Code: FC = ({ children }) => {
+type Props = PropsWithChildren<unknown>;
+
+const Code = (props: Props): JSX.Element => {
+  const { children } = props;
+
   return (
     <code data-testid="Code" className="code">
       {children}

--- a/src/elements/blockcode/Pre.tsx
+++ b/src/elements/blockcode/Pre.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from "react";
+import React, { PropsWithChildren } from "react";
 
 import css from "styled-jsx/css";
 
@@ -282,7 +282,11 @@ const styles = css.global`
   }
 `;
 
-const Pre: FC = ({ children }) => {
+type Props = PropsWithChildren<unknown>;
+
+const Pre = (props: Props): JSX.Element => {
+  const { children } = props;
+
   return (
     <pre data-testid="Pre" className="hljs">
       {children}

--- a/src/elements/blockquote/Blockquote.tsx
+++ b/src/elements/blockquote/Blockquote.tsx
@@ -1,10 +1,13 @@
-import React, { ComponentPropsWithoutRef, FC } from "react";
+import React, { ComponentPropsWithoutRef, PropsWithChildren } from "react";
 
 import Icon from "../icon/Icon";
 
-export type Props = ComponentPropsWithoutRef<"div">;
+export type Props = PropsWithChildren<unknown> &
+  Omit<ComponentPropsWithoutRef<"div">, "className">;
 
-const Blockquote: FC<Props> = ({ children, ...rest }) => {
+const Blockquote = (props: Props): JSX.Element => {
+  const { children, ...rest } = props;
+
   return (
     <div data-testid="Blockquote" className="blockquote" {...rest}>
       <div className="icon">

--- a/src/elements/chip/Chip.tsx
+++ b/src/elements/chip/Chip.tsx
@@ -1,13 +1,16 @@
-import React, { ComponentPropsWithoutRef, FC } from "react";
+import React, { ComponentPropsWithoutRef, PropsWithChildren } from "react";
 
 import { textColor } from "../../styles/mixin";
 import Icon, { tagList, TagType } from "../icon/Icon";
 
-export type Props = {
+export type Props = PropsWithChildren<{
   icon?: TagType;
-} & Omit<ComponentPropsWithoutRef<"div">, "className">;
+}> &
+  Omit<ComponentPropsWithoutRef<"div">, "className">;
 
-const Chip: FC<Props> = ({ children, icon, ...rest }) => {
+const Chip = (props: Props): JSX.Element => {
+  const { children, icon, ...rest } = props;
+
   return (
     <div data-testid="Chip" className="chip" {...rest}>
       {icon ? (

--- a/src/elements/container/Container.tsx
+++ b/src/elements/container/Container.tsx
@@ -1,10 +1,13 @@
-import React, { ComponentPropsWithoutRef, FC } from "react";
+import React, { ComponentPropsWithoutRef, PropsWithChildren } from "react";
 
 import { containerSize } from "../../styles/const";
 
-type Props = Omit<ComponentPropsWithoutRef<"div">, "className">;
+type Props = PropsWithChildren<unknown> &
+  Omit<ComponentPropsWithoutRef<"div">, "className">;
 
-const Container: FC<Props> = ({ children, ...rest }) => {
+const Container = (props: Props): JSX.Element => {
+  const { children, ...rest } = props;
+
   return (
     <div data-testid="Container" className="container" {...rest}>
       <div className="inner">{children}</div>

--- a/src/elements/heading/Heading.tsx
+++ b/src/elements/heading/Heading.tsx
@@ -1,13 +1,16 @@
-import React, { FC, createElement, HTMLAttributes } from "react";
+import React, { createElement, HTMLAttributes, PropsWithChildren } from "react";
 
 import { slug } from "github-slugger";
 import { onlyText } from "react-children-utilities";
 
-export type Props = {
+export type Props = PropsWithChildren<{
   level?: number;
-} & Omit<HTMLAttributes<HTMLHeadingElement>, "className">;
+}> &
+  Omit<HTMLAttributes<HTMLHeadingElement>, "className">;
 
-const Heading: FC<Props> = ({ level = 1, children, ...rest }) => {
+const Heading = (props: Props): JSX.Element => {
+  const { level = 1, children, ...rest } = props;
+
   const text = onlyText(children);
   const id = slug(text);
 

--- a/src/elements/icon/Icon.tsx
+++ b/src/elements/icon/Icon.tsx
@@ -1,4 +1,4 @@
-import React, { ComponentPropsWithoutRef, FC } from "react";
+import React, { ComponentPropsWithoutRef, PropsWithChildren } from "react";
 
 export const tagList = {
   amp: "#005AF0",
@@ -36,11 +36,14 @@ export type IconType =
   | "star"
   | TagType;
 
-type Props = {
+type Props = PropsWithChildren<{
   name: IconType;
-} & Omit<ComponentPropsWithoutRef<"svg">, "className">;
+}> &
+  Omit<ComponentPropsWithoutRef<"svg">, "className">;
 
-const Icon: FC<Props> = ({ name, ...rest }) => {
+const Icon = (props: Props): JSX.Element => {
+  const { name, ...rest } = props;
+
   const svgRestProps = {
     width: 24,
     height: 24,

--- a/src/elements/link/ExternalLink.tsx
+++ b/src/elements/link/ExternalLink.tsx
@@ -1,9 +1,7 @@
-import React, { ComponentPropsWithoutRef, FC } from "react";
+import React, { ComponentPropsWithoutRef, PropsWithChildren } from "react";
 
-type NoTargetElement = Omit<
-  ComponentPropsWithoutRef<"a">,
-  "target" | "className"
->;
+type NoTargetElement = PropsWithChildren<unknown> &
+  Omit<ComponentPropsWithoutRef<"a">, "target" | "className">;
 
 type Props = {
   disableVisited?: boolean;
@@ -19,11 +17,11 @@ const addRel = (props: NoTargetElement): NoTargetElement => {
   };
 };
 
-const ExternalLink: FC<Props> = ({
+const ExternalLink = ({
   children,
   disableVisited = false,
   ...rest
-}) => {
+}: Props): JSX.Element => {
   return (
     <a target="_blank" className="link" {...addRel(rest)}>
       {children}

--- a/src/elements/margin/Margin.tsx
+++ b/src/elements/margin/Margin.tsx
@@ -1,12 +1,11 @@
-import React, { ComponentPropsWithoutRef, FC } from "react";
+import React, { ComponentPropsWithoutRef, PropsWithChildren } from "react";
 
-// @todo hooksにすること
 export const toRem = (val?: number): string => {
   if (!val) return "0";
   return `calc(1.5rem * ${val})`;
 };
 
-type Props = {
+type Props = PropsWithChildren<{
   all?: number;
   x?: number;
   y?: number;
@@ -14,18 +13,12 @@ type Props = {
   bottom?: number;
   left?: number;
   right?: number;
-} & Omit<ComponentPropsWithoutRef<"div">, "className">;
+}> &
+  Omit<ComponentPropsWithoutRef<"div">, "className">;
 
-const Margin: FC<Props> = ({
-  children,
-  all,
-  x,
-  y,
-  top,
-  bottom,
-  left,
-  right,
-}) => {
+const Margin = (props: Props): JSX.Element => {
+  const { children, all, x, y, top, bottom, left, right } = props;
+
   const topRem = toRem(top ?? y ?? all);
   const bottomRem = toRem(bottom ?? y ?? all);
   const leftRem = toRem(left ?? x ?? all);

--- a/src/elements/markdown/Markdown.tsx
+++ b/src/elements/markdown/Markdown.tsx
@@ -1,4 +1,4 @@
-import React, { ComponentPropsWithoutRef, FC } from "react";
+import React, { ComponentPropsWithoutRef, PropsWithChildren } from "react";
 
 import { imageSize } from "image-size";
 import ReactMarkdown from "react-markdown";
@@ -11,27 +11,35 @@ import Heading from "../heading/Heading";
 import ExternalLink from "../link/ExternalLink";
 import ResponsiveTable from "../table/ResponsiveTable";
 
-type Props = {
+type Props = PropsWithChildren<{
   source: string;
-} & Omit<ComponentPropsWithoutRef<"div">, "className">;
+}> &
+  Omit<ComponentPropsWithoutRef<"div">, "className">;
 
-const Markdown: FC<Props> = ({ source, ...rest }) => {
-  const code: FC<{ language: string; value: string }> = ({
-    language,
-    value,
-  }) => {
+const Markdown = (props: Props): JSX.Element => {
+  const { source, ...rest } = props;
+
+  const code = (props: { language: string; value: string }) => {
+    const { language, value } = props;
+
     return <Blockcode language={language}>{value}</Blockcode>;
   };
 
-  const section: FC = ({ children }) => {
+  const section = (props: PropsWithChildren<unknown>) => {
+    const { children } = props;
+
     return <section>{children}</section>;
   };
 
-  const heading: FC<{ level: string }> = ({ level, children }) => {
+  const heading = (props: PropsWithChildren<{ level: string }>) => {
+    const { level, children } = props;
+
     return <Heading level={parseInt(level)}>{children}</Heading>;
   };
 
-  const image: FC<{ src: string; alt: string }> = ({ src, alt }) => {
+  const image = (props: PropsWithChildren<{ src: string; alt: string }>) => {
+    const { src, alt } = props;
+
     const dimensions = imageSize(`public/${src}`);
 
     return (
@@ -52,7 +60,9 @@ const Markdown: FC<Props> = ({ source, ...rest }) => {
     );
   };
 
-  const link: FC<{ href: string }> = ({ children, href }) => {
+  const link = (props: PropsWithChildren<{ href: string }>) => {
+    const { children, href } = props;
+
     if (href.startsWith("http")) {
       return <ExternalLink href={href}>{children}</ExternalLink>;
     }
@@ -60,11 +70,15 @@ const Markdown: FC<Props> = ({ source, ...rest }) => {
     return <a href={href}>{children}</a>;
   };
 
-  const blockquote: FC = ({ children }) => {
+  const blockquote = (props: PropsWithChildren<unknown>) => {
+    const { children } = props;
+
     return <Blockquote>{children}</Blockquote>;
   };
 
-  const table: FC = ({ children }) => {
+  const table = (props: PropsWithChildren<unknown>) => {
+    const { children } = props;
+
     return <ResponsiveTable>{children}</ResponsiveTable>;
   };
 

--- a/src/elements/rating/Rating.tsx
+++ b/src/elements/rating/Rating.tsx
@@ -1,15 +1,18 @@
-import React, { ComponentPropsWithoutRef, FC } from "react";
+import React, { ComponentPropsWithoutRef, PropsWithChildren } from "react";
 
 import classNames from "classnames";
 
 import Icon from "../icon/Icon";
 
-export type Props = {
+export type Props = PropsWithChildren<{
   rate: number;
   maxRate?: number;
-} & Omit<ComponentPropsWithoutRef<"div">, "className">;
+}> &
+  Omit<ComponentPropsWithoutRef<"div">, "className">;
 
-const Rating: FC<Props> = ({ rate, maxRate = 3, ...rest }) => {
+const Rating = (props: Props): JSX.Element => {
+  const { rate, maxRate = 3, ...rest } = props;
+
   if (rate > maxRate) {
     throw new Error("rateにmaxRateよりも大きい数値が設定されています。");
   }

--- a/src/elements/table/ResponsiveTable.tsx
+++ b/src/elements/table/ResponsiveTable.tsx
@@ -1,10 +1,13 @@
-import React, { ComponentPropsWithoutRef, FC } from "react";
+import React, { ComponentPropsWithoutRef, PropsWithChildren } from "react";
 
-type Props = {
+type Props = PropsWithChildren<{
   language?: string;
-} & Omit<ComponentPropsWithoutRef<"table">, "className">;
+}> &
+  Omit<ComponentPropsWithoutRef<"table">, "className">;
 
-const ResponsiveTable: FC<Props> = ({ children, ...rest }) => {
+const ResponsiveTable = (props: Props): JSX.Element => {
+  const { children, ...rest } = props;
+
   return (
     <div className="responsiveTable">
       <table className="table" {...rest}>

--- a/src/templates/DefaultTemplate.tsx
+++ b/src/templates/DefaultTemplate.tsx
@@ -1,9 +1,13 @@
-import React, { FC } from "react";
+import React, { PropsWithChildren } from "react";
 
 import Footer from "../components/footer/Footer";
 import Header from "../components/header/Header";
 
-const DefaultTemplate: FC = ({ children }) => {
+type Props = PropsWithChildren<unknown>;
+
+const DefaultTemplate = (props: Props): JSX.Element => {
+  const { children } = props;
+
   return (
     <div className="root">
       <div className="header">


### PR DESCRIPTION
close #718

## 概要

React.FCを廃止して、PropsWithChildrenを使うように変更した。